### PR TITLE
Improve share link functionality with fallback options

### DIFF
--- a/projects/hotncold/js/hotncold.js
+++ b/projects/hotncold/js/hotncold.js
@@ -88,10 +88,20 @@ views.share = {
         this.playLink.attr('href', this.gameUrl);
         var gameUrl = this.gameUrl;
         $('#copy_link').on('click', function () {
-            navigator.clipboard.writeText(gameUrl).then(function () {
-                $('#copy_link').text('Copied!');
-                setTimeout(function () { $('#copy_link').text('Copy link'); }, 2000);
-            });
+            var btn = $('#copy_link');
+            var onSuccess = function () {
+                btn.text('Copied!');
+                setTimeout(function () { btn.text('Copy link'); }, 2000);
+            };
+            if (navigator.share) {
+                navigator.share({ url: gameUrl }).then(onSuccess).catch(function () {});
+            } else if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(gameUrl).then(onSuccess).catch(function () {
+                    prompt('Copy this link:', gameUrl);
+                });
+            } else {
+                prompt('Copy this link:', gameUrl);
+            }
         });
     }
 };


### PR DESCRIPTION
## Summary
Enhanced the "Copy link" button in the share view to support multiple sharing mechanisms with graceful fallbacks, improving compatibility across different browsers and devices.

## Key Changes
- **Added Web Share API support**: Uses native `navigator.share()` when available for a better native sharing experience on mobile devices
- **Improved clipboard fallback**: Maintains clipboard API as a secondary option with a prompt fallback if clipboard write fails
- **Universal fallback**: Implements `prompt()` as a last resort for browsers that don't support modern APIs
- **Code refactoring**: Extracted the success callback into a reusable function to avoid duplication across different code paths

## Implementation Details
The updated logic follows a priority order:
1. **Web Share API** (`navigator.share`) - Preferred for mobile/native sharing
2. **Clipboard API** (`navigator.clipboard.writeText`) - Standard modern approach with prompt fallback on failure
3. **Prompt dialog** - Fallback for older browsers or when clipboard access is denied

This ensures the share functionality works across a wider range of browsers and devices while providing the best user experience available on each platform.

https://claude.ai/code/session_0119Gzso5j3ygg9E7fx9cHYA