### PR TITLE
Fix mobile padding on share link and copy button on iOS Safari

### DIFF
--- a/projects/hotncold/css/screen.css
+++ b/projects/hotncold/css/screen.css
@@ -228,6 +228,7 @@ ol li {
     display: block;
     width: 100%;
     padding: 10px;
+    box-sizing: border-box;
     text-align: center;
     font-size: 11px;
     font-weight: bold;

--- a/projects/hotncold/js/hotncold.js
+++ b/projects/hotncold/js/hotncold.js
@@ -93,14 +93,26 @@ views.share = {
                 btn.text('Copied!');
                 setTimeout(function () { btn.text('Copy link'); }, 2000);
             };
-            if (navigator.share) {
-                navigator.share({ url: gameUrl }).then(onSuccess).catch(function () {});
-            } else if (navigator.clipboard && navigator.clipboard.writeText) {
-                navigator.clipboard.writeText(gameUrl).then(onSuccess).catch(function () {
+            var copyViaExecCommand = function () {
+                var textarea = document.createElement('textarea');
+                textarea.value = gameUrl;
+                textarea.style.position = 'fixed';
+                textarea.style.opacity = '0';
+                document.body.appendChild(textarea);
+                textarea.focus();
+                textarea.select();
+                try {
+                    document.execCommand('copy');
+                    onSuccess();
+                } catch (e) {
                     prompt('Copy this link:', gameUrl);
-                });
+                }
+                document.body.removeChild(textarea);
+            };
+            if (navigator.clipboard && navigator.clipboard.writeText) {
+                navigator.clipboard.writeText(gameUrl).then(onSuccess).catch(copyViaExecCommand);
             } else {
-                prompt('Copy this link:', gameUrl);
+                copyViaExecCommand();
             }
         });
     }


### PR DESCRIPTION
- Add box-sizing: border-box to #play_link so padding doesn't overflow the container on the right
- Replace navigator.share with navigator.clipboard + execCommand fallback so COPY LINK works on mobile Safari

https://claude.ai/code/session_014TJkjuiw5kpGRCK6J9X5Nk